### PR TITLE
Set timers to 1 minute max since React Native on Android does not han…

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { StyleSheet } from 'react-native';
+import { ReactQueryConfigProvider } from 'react-query';
 import { SplashScreen } from 'expo';
 import * as Font from 'expo-font';
 import { Ionicons } from '@expo/vector-icons';
@@ -24,6 +25,12 @@ import * as Sentry from 'sentry-expo';
 import Constants from 'expo-constants';
 
 import useNotificationHandler from '~/h/useNotificationHandler';
+
+const queryConfig = {
+  queries: {
+    cacheTime: 1 * 60 * 1000, // 1 minute max, due to https://github.com/facebook/react-native/issues/12981
+  },
+};
 
 Sentry.init({
   dsn: 'https://5798596b010948678b643700db20d942@sentry.io/5178537',
@@ -70,24 +77,26 @@ export default function App(props) {
     return null;
   } else {
     return (
-      <AppearanceProvider>
-        <ThemeAwareStatusBar />
-        <Provider store={configureStore({ auth: AuthToken.get() })}>
-          <AuthGate>
-            <ProfileGate>
-              <NotificationGate>
-                <CableContainer />
-                <NavigationContainer
-                  ref={containerRef}
-                  initialState={initialNavigationState}
-                >
-                  <HomeStack />
-                </NavigationContainer>
-              </NotificationGate>
-            </ProfileGate>
-          </AuthGate>
-        </Provider>
-      </AppearanceProvider>
+      <ReactQueryConfigProvider config={queryConfig}>
+        <AppearanceProvider>
+          <ThemeAwareStatusBar />
+          <Provider store={configureStore({ auth: AuthToken.get() })}>
+            <AuthGate>
+              <ProfileGate>
+                <NotificationGate>
+                  <CableContainer />
+                  <NavigationContainer
+                    ref={containerRef}
+                    initialState={initialNavigationState}
+                  >
+                    <HomeStack />
+                  </NavigationContainer>
+                </NotificationGate>
+              </ProfileGate>
+            </AuthGate>
+          </Provider>
+        </AppearanceProvider>
+      </ReactQueryConfigProvider>
     );
   }
 }

--- a/c/StatusBadge.js
+++ b/c/StatusBadge.js
@@ -30,7 +30,7 @@ export default function StatusBadge({ statusColor, style, size, lastSeen }) {
     () => {
       setIcon(getIcon(lastSeen));
     },
-    onlineNow ? 2000 : 1000 * 60 * 60
+    onlineNow ? 2000 : 1000 * 60
   );
   return (
     <View

--- a/c/TimeAgoOnline.js
+++ b/c/TimeAgoOnline.js
@@ -19,13 +19,8 @@ const getInterval = (timeDisplay) => {
   if (timeDisplay.endsWith('s')) {
     return 1000;
   }
-  if (timeDisplay.endsWith('m')) {
-    return 1000 * 60;
-  }
-  if (timeDisplay.endsWith('h')) {
-    return 1000 * 60 * 60;
-  }
-  return 1000 * 60 * 60 * 24;
+  // Default value must be at most 1 minute due to how React Native on Android handles timers.
+  return 1000 * 60;
 };
 
 const TimeAgo = ({ time }) => {


### PR DESCRIPTION
…dle > 1 minute well

Sets query cache time default value to 1 minute since React Native on Android cannot handle timers > 1 minute.
Removes other timers > 1 minute and replaces with a default max timer of 1 minute.